### PR TITLE
Use random seed serial for crl db

### DIFF
--- a/pkictl
+++ b/pkictl
@@ -52,7 +52,7 @@ init_ca_db() {
     cp /dev/null "${caPath}/db/${caName}.db"
     cp /dev/null "${caPath}/db/${caName}.db.attr"
     echo 01 > "${caPath}/db/${caName}.crt.srl"
-    echo 01 > "${caPath}/db/${caName}.crl.srl"
+    openssl rand -hex 16 > "${caPath}/db/${caName}.crl.srl"
 }
 
 init_import_folders() {


### PR DESCRIPTION
For consistency with openssl's own random serial generator, the seed serial number for the crl database should also be a random.
