### PR TITLE
Add env var to override default_days

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ that which is already setup via configuration files. To use:
           alternate distinguished name matching policies for signing your
           certificate. When unset, defaults from your configuration file are
           used.
+        * `PKICTL_CA_DAYS`: set this prior to signing commands to override the
+          number of days to certify a certificate for as set on the config file.
     * PKCS#12 Import Settings
         * `$PKICTL_SSL_DIR`: defaults to `/etc/ssl`, make sure this coincides
           with where your operating system's OpenSSL installation stores its

--- a/pkictl
+++ b/pkictl
@@ -94,26 +94,30 @@ sign_root_ca_request() {
         openssl ca -selfsign \
             -config "$conf" \
             -in "${caPath}/${csrName}.csr" \
-            -out "${caPath}/${outName}.crt"
+            -out "${caPath}/${outName}.crt" \
+            -days "$PKICTL_CA_DAYS"
     elif [[ "$PKICTL_CA_EXTENSIONS" != "" ]] && [[ "$PKICTL_CA_POLICY" == "" ]]; then
         openssl ca -selfsign \
             -config "$conf" \
             -in "${caPath}/${csrName}.csr" \
             -out "${caPath}/${outName}.crt" \
-            -extensions "$PKICTL_CA_EXTENSIONS"
+            -extensions "$PKICTL_CA_EXTENSIONS" \
+            -days "$PKICTL_CA_DAYS"
     elif [[ "$PKICTL_CA_EXTENSIONS" == "" ]] && [[ "$PKICTL_CA_POLICY" != "" ]]; then
         openssl ca -selfsign \
             -config "$conf" \
             -in "${caPath}/${csrName}.csr" \
             -out "${caPath}/${outName}.crt" \
-            -policy "$PKICTL_CA_POLICY"
+            -policy "$PKICTL_CA_POLICY" \
+            -days "$PKICTL_CA_DAYS"
     else
         openssl ca -selfsign \
             -config "$conf" \
             -in "${caPath}/${csrName}.csr" \
             -out "${caPath}/${outName}.crt" \
             -policy "$PKICTL_CA_POLICY" \
-            -extensions "$PKICTL_CA_EXTENSIONS"
+            -extensions "$PKICTL_CA_EXTENSIONS" \
+            -days "$PKICTL_CA_DAYS"
     fi
 
     if [[ "$?" -eq 0 ]]; then
@@ -135,26 +139,30 @@ sign_request() {
         openssl ca \
             -config "$conf" \
             -in "$inCsr" \
-            -out "$outCrt"
+            -out "$outCrt" \
+            -days "$PKICTL_CA_DAYS"
     elif [[ "$PKICTL_CA_EXTENSIONS" != "" ]] && [[ "$PKICTL_CA_POLICY" == "" ]]; then
         openssl ca \
             -config "$conf" \
             -in "$inCsr" \
             -out "$outCrt" \
-            -extensions "$PKICTL_CA_EXTENSIONS"
+            -extensions "$PKICTL_CA_EXTENSIONS" \
+            -days "$PKICTL_CA_DAYS"
     elif [[ "$PKICTL_CA_EXTENSIONS" == "" ]] && [[ "$PKICTL_CA_POLICY" != "" ]]; then
         openssl ca \
             -config "$conf" \
             -in "$inCsr" \
             -out "$outCrt" \
-            -policy "$PKICTL_CA_POLICY"
+            -policy "$PKICTL_CA_POLICY" \
+            -days "$PKICTL_CA_DAYS"
     else
         openssl ca \
             -config "$conf" \
             -in "$inCsr" \
             -out "$outCrt" \
             -policy "$PKICTL_CA_POLICY" \
-            -extensions "$PKICTL_CA_EXTENSIONS"
+            -extensions "$PKICTL_CA_EXTENSIONS" \
+            -days "$PKICTL_CA_DAYS"
     fi
 
     if [[ "$?" -eq 0 ]]; then


### PR DESCRIPTION
This is interesting so that you can have a root CA signing certificates valid for a certain validity (e.g. `default_days = 5478` (~15 years) which would work for intermediate CAs, but at the same time allow itself to have a longer validity (e.g. 30 years).

``` bash
PKICTL_CA_DAYS=10957 ./pkictl rootca sign
```
